### PR TITLE
perf: wait before sync after initializing with nppiMalloc

### DIFF
--- a/src/accelerator/jpeg_compressor.cpp
+++ b/src/accelerator/jpeg_compressor.cpp
@@ -132,11 +132,7 @@ CompressedImage::UniquePtr JetsonCompressor::compress(const Image &msg, int qual
       // Synchronize CUDA device to ensure memory allocation is complete
       std::this_thread::sleep_for(std::chrono::milliseconds(300));
       cudaError_t cudaStatus = cudaDeviceSynchronize();
-      if (cudaStatus != cudaSuccess) {
-          // Handle error
-          fprintf(stderr, "cudaDeviceSynchronize failed: %s\n", cudaGetErrorString(cudaStatus));
-          // You may want to throw an exception or handle the error appropriately
-      }
+      CHECK_CUDA(cudaStatus);
     }
 
     TEST_ERROR(cudaMemcpy2DAsync(static_cast<void*>(dev_image_), dev_image_step_bytes_,


### PR DESCRIPTION
## PR Type

<!-- Select one and remove others. If an appropriate one is not listed, please write by yourself. -->

- Bug Fix

## Related Links

<!-- Please write related links to GitHub/Jira/Slack/etc. -->

https://github.com/tier4/accelerated_image_processor/pull/3#discussion_r1836145741

## Description

<!-- Describe what this PR changes. -->

When the GPU load is heavy and the CPU moves fast.

As described in the code:
1. `nppiMalloc_8u_C1` will **asynchronously** initialize an aligned size for the array.
2. Until the asynchronous function `nppiMalloc_8u_C1` finished, the value for `dev_yuv_step_bytes_` will remain undefined in CPU.
3. If the CPU happens to be faster, and reaches `nppiRGBToYUV420_8u_C3P3R_Ctx` where we need to use `dev_yuv_step_bytes_`, it will directly queue the function with undefined values.
4. Which cause node dying error.
5. This could happens when we trying to launch multiple cameras together.

The modification:
1. The code will now take time to wait before progressing, making sure that the dev_yuv_step_bytes_ has been defined in CPU.
2. The initialization will be a bit slower. However, generally given that the image size does not change for each node, the computation latency will not change for a normally running node.

## Review Procedure

<!-- Explain how to review this PR. -->

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [ ] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
