### PR TITLE
fix: libjpegturbo related error on build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,7 +108,7 @@ if (JETSON)
   target_link_libraries(jpeg_compressor
     ${CUDA_nppicc_LIBRARY}
     ${CUDA_nppidei_LIBRARY}
-    <$<BOOL:${LibJpegTurbo_FOUND}:${LIBJPEGTURBO_LIBRARIES}>
+    $<$<BOOL:${LibJpegTurbo_FOUND}>:${LIBJPEGTURBO_LIBRARIES}>
     nvjpeg
     cuda-api-wrappers::runtime-and-driver
     color_space

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,7 +108,7 @@ if (JETSON)
   target_link_libraries(jpeg_compressor
     ${CUDA_nppicc_LIBRARY}
     ${CUDA_nppidei_LIBRARY}
-    ${LIBJPEGTURBO_LIBRARIES}
+    <$<BOOL:${LibJpegTurbo_FOUND}:${LIBJPEGTURBO_LIBRARIES}>
     nvjpeg
     cuda-api-wrappers::runtime-and-driver
     color_space
@@ -176,8 +176,8 @@ else()
   )
   target_link_libraries(jpeg_compressor
     ${CUDA_nppicc_LIBRARY}
-    ${LibJpegTurbo_LIBRARY}
-    ${NVJPEG_LIBRARY}
+    $<$<BOOL:${LibJpegTurbo_FOUND}>:${LibJpegTurbo_LIBRARY}>
+    $<$<BOOL:${NVJPEG_FOUND}>:${NVJPEG_LIBRARY}>
     ${CUDART_LIBRARY}
     ${CULIBOS}
     # nvjpeg

--- a/src/accelerator/jpeg_compressor.cpp
+++ b/src/accelerator/jpeg_compressor.cpp
@@ -65,7 +65,12 @@ CompressedImage::UniquePtr CPUCompressor::compress(const Image &msg, int quality
                             quality,
                             TJFLAG_FASTDCT);
 
+#if defined(LIBJPEG_TURBO_VERSION) && (LIBJPEG_TURBO_VERSION >= 2)
     TEST_ERROR(tjres != 0, tjGetErrorStr2(handle_));
+#else
+    TEST_ERROR(tjres != 0, tjGetErrorStr());
+#endif
+
 
     compressed_msg->data.resize(size_);
     memcpy(compressed_msg->data.data(), jpegBuf_, size_);


### PR DESCRIPTION
## PR Type

<!-- Select one and remove others. If an appropriate one is not listed, please write by yourself. -->

- Bug Fix

## Related Links

<!-- Please write related links to GitHub/Jira/Slack/etc. -->

## Description

<!-- Describe what this PR changes. -->
This PR fixes build errors on certain environments, such as with libjpegturbo < ver.2 or without libjpegturbo.
The errors were observed in relatively old environments like Jetpack 5.1.2., and confirmed that the modification by this PR fixed the errors.

## Review Procedure

<!-- Explain how to review this PR. -->
Just build the package:
```bash
colcon build --symlink-install --cmake-clean-cache \
  --cmake-args -DCMAKE_BUILD_TYPE=Release \
  --packages-up-to accelerated_image_processor
```

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [ ] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
