### PR TITLE
fix: use proper packet component

### DIFF
--- a/src/accelerated_image_processor_compression/src/video_compressor/jetson.cpp
+++ b/src/accelerated_image_processor_compression/src/video_compressor/jetson.cpp
@@ -489,8 +489,8 @@ bool JetsonVideoCompressor::encoder_capture_plane_dq_callback(
   }
 
   // Get encode metadata
-  v4l2_ctrl_videoenc_outputbuf_metadata enc_metadata;
-  encoder->getMetadata(v4l2_buf->index, enc_metadata);
+  v4l2_ctrl_videoenc_outputbuf_metadata enc_metadata{};
+  const bool has_encoder_metadata = encoder->getMetadata(v4l2_buf->index, enc_metadata) == 0;
 
   // Create result data
   common::Image processed;
@@ -510,13 +510,19 @@ bool JetsonVideoCompressor::encoder_capture_plane_dq_callback(
     processed.timestamp = stamp_in_nanosecond;
     processed.height = callback_args->input_height;
     processed.width = callback_args->input_width;
+    // getMetadata() fills enc_metadata via V4L2 ioctl side effect. Use the buffer flag as the
+    // direct fallback so subscribers waiting for AV_PKT_FLAG_KEY can start reliably.
+    const bool is_keyframe =
+      (has_encoder_metadata && enc_metadata.KeyFrame) ||
+      (v4l2_buf->flags & V4L2_BUF_FLAG_KEYFRAME) != 0;
+
     processed.format = supported_codec_format_map.at(compressor_object->codec());
-    processed.pts = stamp_in_nanosecond / 1e3;  // [us]
-    processed.flags = enc_metadata.KeyFrame ? AV_PKT_FLAG_KEY : 0;
+    processed.pts = compressor_object->next_pts_++;
+    processed.flags = is_keyframe ? AV_PKT_FLAG_KEY : 0;
     processed.is_bigendian = is_big_endian;
 
     compressor_object->payload_copy_impl(
-      enc_metadata.KeyFrame, payload_info, callback_args, processed.data);
+      is_keyframe, payload_info, callback_args, processed.data);
   }
 
   // Now, v4l2_buffer can be queued again

--- a/src/accelerated_image_processor_compression/src/video_compressor/jetson.hpp
+++ b/src/accelerated_image_processor_compression/src/video_compressor/jetson.hpp
@@ -18,6 +18,7 @@
 #include "jetson_precise_timestamp_map.hpp"
 
 #include <atomic>
+#include <cstdint>
 #include <iostream>
 #include <memory>
 #include <string>
@@ -376,6 +377,7 @@ private:
   std::unique_ptr<DqCallbackArgs> dq_callback_args_;
 
   int initial_frame_count_{0};
+  uint64_t next_pts_{0};
 };
 #endif  // JETSON_AVAILABLE
 }  // namespace accelerated_image_processor::compression

--- a/src/accelerated_image_processor_compression/test/test_utility.hpp
+++ b/src/accelerated_image_processor_compression/test/test_utility.hpp
@@ -141,7 +141,7 @@ public:
     EXPECT_LE(result.data.size(), image_size_);
     // expect the pts field has values larger than zero
     EXPECT_TRUE(result.pts.has_value());
-    EXPECT_GT(result.pts.value(), 0);
+    EXPECT_GE(result.pts.value(), 0);
     // expect flag should be 0 or 1
     EXPECT_TRUE(result.flags.has_value());
     if (result.flags.value() == 1 && frame_from_first_i_frame_ == std::nullopt) {


### PR DESCRIPTION
## PR Type

<!-- Select one and remove others. If an appropriate one is not listed, please write by yourself. -->

- Bug Fix

## Related Links

<!-- Please write related links to GitHub/Jira/Slack/etc. -->
N/A

## Description

<!-- Describe what this PR changes. -->

The `ffmpeg_image_transport_msgs::msg::FFMPEGPacket` topic published by the current implementation cannot be decoded by `ffmpeg_image_transport` in the following setup:

```bash
$ ros2 run image_transport republish ffmpeg raw \
        --ros-args \
        -r /in/ffmpeg:=/image_raw/compressed \
        -r out:=/image_raw/decompressed \
        -r __node:=dec
```

The decoder opens successfully, but then repeatedly reports the following error:

```bash
[WARN 1781876080.916621098] [FFMPEGSubscriber]: no decoders configured for encoding av1 defaulting to: av1_cuvid,libdav1d,libaom-av1,av1,av1_qsv
[INFO 1781876080.916661621] [FFMPEGSubscriber]: trying decoders in order: av1_cuvid,libdav1d,libaom-av1,av1,av1_qsv
[INFO 1781876080.916703143] [Decoder]: output image encoding: bgr8 (default)
[INFO 1781876080.916786466] [Decoder]: decoder av1_cuvid has hw accelerator: cuda
[INFO 1781876081.154636255] [Decoder]: using hardware acceleration: cuda
[INFO 1781876081.154665342] [Decoder]: using decoder  av1_cuvid with options:
[INFO 1781876081.171936124] [Decoder]: decoding with av1_cuvid
[INFO 1781876081.188670206] [FFMPEGSubscriber]: successfully opened decoder av1_cuvid
[ERROR 1781876081.213356953] [Decoder]: cannot find pts that matches -92233720368548
[ERROR 1781876081.311615151] [Decoder]: cannot find pts that matches -92233720368548
...
```

This happens because one of the fields in `FFMPEGPacket` is populated with an invalid value. This PR fixes the packet field value so that the published ffmpeg transport topic can be decoded correctly.

## Review Procedure

<!-- Explain how to review this PR. -->

Build the package
```bash
colcon build --symlink-install \
  --cmake-args -DCMAKE_BUILD_TYPE=Release \
  --packages-up-to accelerated_image_processor_ros
```

Launch `accelerated_image_processor_ros/imgproc.launch.xml`
<details>
<summary>Test launch file</summary>

``` xml
<?xml version="1.0" encoding="UTF-8"?>
<launch>
  <arg name="image_path" default="$(dirname)/dog2.jpg"/>
  <arg name="param_path" default="$(dirname)/av1_ssim-false_bpp_02.param.yaml"/>

  <node pkg="image_publisher" exec="image_publisher_node" name="test_image_publisher" output="screen">
    <param name="filename" value="$(var image_path)"/>
    <remap from="image_raw" to="/image_raw"/>
    <param name="image_raw.enable_pub_plugins" value="[image_transport/raw]"/>
  </node>

  <include file="$(find-pkg-share accelerated_image_processor_ros)/launch/imgproc.launch.xml">
    <arg name="param_path" value="$(var param_path)"/>
    <arg name="input/image_raw" value="/image_raw"/>
    <arg name="output/image_raw/compressed" value="/image_raw/compressed"/>
  </include>
</launch>
```

</details>

Check that the decoder starts successfully and does not report cannot find pts errors:

```bash
$ ros2 run image_transport republish ffmpeg raw \
        --ros-args \
        -r /in/ffmpeg:=/image_raw/compressed \
        -r out:=/image_raw/decompressed \
        -r __node:=dec
[WARN 1781876240.304190001] [FFMPEGSubscriber]: no decoders configured for encoding av1 defaulting to: av1_cuvid,libdav1d,libaom-av1,av1,av1_qsv
[INFO 1781876240.304244327] [FFMPEGSubscriber]: trying decoders in order: av1_cuvid,libdav1d,libaom-av1,av1,av1_qsv
[INFO 1781876240.304272537] [Decoder]: output image encoding: bgr8 (default)
[INFO 1781876240.304320498] [Decoder]: decoder av1_cuvid has hw accelerator: cuda
[INFO 1781876240.466062889] [Decoder]: using hardware acceleration: cuda
[INFO 1781876240.466090613] [Decoder]: using decoder  av1_cuvid with options:
[INFO 1781876240.483503099] [Decoder]: decoding with av1_cuvid
[INFO 1781876240.499994492] [FFMPEGSubscriber]: successfully opened decoder av1_cuvid
```

I also confirmed that all unit tests pass.

```bash
$ colcon test --event-handlers console_cohesion+ \
  --packages-select accelerated_image_processor_ros accelerated_image_processor_compression
Starting >>> accelerated_image_processor_compression

# ...

279/279 Test #279: nv_jpeg_compressor.cpp_accelerated_image_processor_compression ..................................................................................   Passed    0.09 sec

100% tests passed, 0 tests failed out of 279

Label Time Summary:
gtest    =   1.07 sec*proc (4 tests)

Total Test time (real) = 342.35 sec
---
Finished <<< accelerated_image_processor_compression [5min 42s]
Starting >>> accelerated_image_processor_ros


# ...

3/3 Test #3: qos.cpp_accelerated_image_processor_ros ..........   Passed    2.56 sec

100% tests passed, 0 tests failed out of 3

Label Time Summary:
gtest    =   3.61 sec*proc (3 tests)

Total Test time (real) =   3.61 sec
---
Finished <<< accelerated_image_processor_ros [3.65s]
```

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
