### PR TITLE
fix: enable to install python binding on non-ROS environment

### DIFF
--- a/src/accelerated_image_processor_common/CMakeLists.txt
+++ b/src/accelerated_image_processor_common/CMakeLists.txt
@@ -11,7 +11,9 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
-find_package(ament_cmake REQUIRED)
+if(NOT SKBUILD)
+  find_package(ament_cmake REQUIRED)
+endif()
 
 add_library(${PROJECT_NAME} INTERFACE)
 
@@ -23,10 +25,12 @@ target_include_directories(
 install(TARGETS ${PROJECT_NAME} EXPORT export_${PROJECT_NAME})
 install(DIRECTORY include/${PROJECT_NAME} DESTINATION include)
 
-if(BUILD_TESTING)
+if(BUILD_TESTING AND NOT SKBUILD)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
 endif()
 
-ament_export_targets(export_${PROJECT_NAME})
-ament_package()
+if(NOT SKBUILD)
+  ament_export_targets(export_${PROJECT_NAME})
+  ament_package()
+endif()

--- a/src/accelerated_image_processor_compression/CMakeLists.txt
+++ b/src/accelerated_image_processor_compression/CMakeLists.txt
@@ -14,8 +14,10 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic -Wunused-function)
 endif()
 
-find_package(ament_cmake_auto REQUIRED)
-ament_auto_find_build_dependencies()
+if(NOT SKBUILD)
+  find_package(ament_cmake_auto REQUIRED)
+  ament_auto_find_build_dependencies()
+endif()
 
 # --- Jetson available? ---
 if(EXISTS "/etc/nv_tegra_release")
@@ -81,7 +83,13 @@ target_link_libraries(
   $<$<TARGET_EXISTS:CUDA::nppidei>:CUDA::nppidei>
   $<$<TARGET_EXISTS:CUDA::nppig>:CUDA::nppig>
   $<$<TARGET_EXISTS:CUDA::nppisu>:CUDA::nppisu>)
-ament_target_dependencies(${PROJECT_NAME} accelerated_image_processor_common)
+if(SKBUILD)
+  target_link_libraries(
+    ${PROJECT_NAME}
+    accelerated_image_processor_common::accelerated_image_processor_common)
+else()
+  ament_target_dependencies(${PROJECT_NAME} accelerated_image_processor_common)
+endif()
 
 if(JETSON_FOUND)
   target_include_directories(${PROJECT_NAME}
@@ -106,8 +114,14 @@ if(JETSON_FOUND)
     /usr/src/jetson_multimedia_api/samples/common/classes/NvBufSurface.cpp)
   target_compile_definitions(${PROJECT_NAME}_jetson PRIVATE JETSON_AVAILABLE)
 
-  ament_target_dependencies(${PROJECT_NAME}_jetson
-                            accelerated_image_processor_common)
+  if(SKBUILD)
+    target_link_libraries(
+      ${PROJECT_NAME}_jetson
+      accelerated_image_processor_common::accelerated_image_processor_common)
+  else()
+    ament_target_dependencies(${PROJECT_NAME}_jetson
+                              accelerated_image_processor_common)
+  endif()
   target_include_directories(
     ${PROJECT_NAME}_jetson
     PRIVATE $<$<BOOL:${CUDAToolkit_FOUND}>:${CUDAToolkit_INCLUDE_DIRS}>
@@ -156,7 +170,7 @@ endif()
 
 install(DIRECTORY include/${PROJECT_NAME} DESTINATION include)
 
-if(BUILD_TESTING)
+if(BUILD_TESTING AND NOT SKBUILD)
   set(test_files test/builder.cpp test/cpu_jpeg_compressor.cpp
                  test/jetson_jpeg_compressor.cpp test/nv_jpeg_compressor.cpp)
 
@@ -191,7 +205,9 @@ if(BUILD_TESTING)
   endforeach()
 endif()
 
-ament_export_include_directories(include)
-ament_export_targets(export_${PROJECT_NAME})
-ament_export_dependencies(accelerated_image_processor_common)
-ament_package()
+if(NOT SKBUILD)
+  ament_export_include_directories(include)
+  ament_export_targets(export_${PROJECT_NAME})
+  ament_export_dependencies(accelerated_image_processor_common)
+  ament_package()
+endif()

--- a/src/accelerated_image_processor_decompression/CMakeLists.txt
+++ b/src/accelerated_image_processor_decompression/CMakeLists.txt
@@ -14,8 +14,10 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic -Wunused-function)
 endif()
 
-find_package(ament_cmake_auto REQUIRED)
-ament_auto_find_build_dependencies()
+if(NOT SKBUILD)
+  find_package(ament_cmake_auto REQUIRED)
+  ament_auto_find_build_dependencies()
+endif()
 
 # find_package(CUDA)
 find_package(CUDAToolkit)
@@ -53,13 +55,20 @@ target_link_libraries(
           ${CUDA_nppidei_LIBRARY} # data exchange and initialization functions
 )
 
-ament_target_dependencies(${PROJECT_NAME} PUBLIC
-                          accelerated_image_processor_common)
+if(SKBUILD)
+  target_link_libraries(
+    ${PROJECT_NAME}
+    PUBLIC
+      accelerated_image_processor_common::accelerated_image_processor_common)
+else()
+  ament_target_dependencies(${PROJECT_NAME} PUBLIC
+                            accelerated_image_processor_common)
+endif()
 
 install(TARGETS ${PROJECT_NAME} EXPORT export_${PROJECT_NAME})
 install(DIRECTORY include/${PROJECT_NAME} DESTINATION include)
 
-if(BUILD_TESTING)
+if(BUILD_TESTING AND NOT SKBUILD)
   find_package(ament_cmake_gtest REQUIRED)
   ament_add_gtest(test_builder test/builder.cpp)
   target_link_libraries(test_builder ${PROJECT_NAME})
@@ -71,7 +80,9 @@ if(BUILD_TESTING)
                         PkgConfig::LIBAV PkgConfig::LIBAVFILTER)
 endif()
 
-ament_export_include_directories(include)
-ament_export_targets(export_${PROJECT_NAME})
-ament_export_dependencies(accelerated_image_processor_common)
-ament_package()
+if(NOT SKBUILD)
+  ament_export_include_directories(include)
+  ament_export_targets(export_${PROJECT_NAME})
+  ament_export_dependencies(accelerated_image_processor_common)
+  ament_package()
+endif()

--- a/src/accelerated_image_processor_python/CMakeLists.txt
+++ b/src/accelerated_image_processor_python/CMakeLists.txt
@@ -19,8 +19,10 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 # find dependencies
-find_package(ament_cmake REQUIRED)
-find_package(python_cmake_module REQUIRED)
+if(NOT SKBUILD)
+  find_package(ament_cmake REQUIRED)
+  find_package(python_cmake_module REQUIRED)
+endif()
 find_package(Python3 REQUIRED COMPONENTS Interpreter Development)
 find_package(Boost REQUIRED COMPONENTS python)
 
@@ -31,7 +33,9 @@ find_package(accelerated_image_processor_decompression REQUIRED)
 
 # define python package name
 set(PYTHON_PACKAGE_NAME accelerated_image_processor)
-ament_python_install_package(${PYTHON_PACKAGE_NAME})
+if(NOT SKBUILD)
+  ament_python_install_package(${PYTHON_PACKAGE_NAME})
+endif()
 
 if(SKBUILD)
   # When scikit-build-core drives the build it defines the SKBUILD variable, so
@@ -116,7 +120,7 @@ aip_add_python_module(decompression)
 install(TARGETS ${PYTHON_MODULE_LIST}
         LIBRARY DESTINATION "${PYTHON_INSTALL_DIR}/${PYTHON_PACKAGE_NAME}")
 
-if(BUILD_TESTING)
+if(BUILD_TESTING AND NOT SKBUILD)
   find_package(ament_cmake_pytest REQUIRED)
   set(test_files test/test_common.py test/test_compression.py
                  test/test_decompression.py)
@@ -135,4 +139,6 @@ if(BUILD_TESTING)
   endforeach()
 endif()
 
-ament_package()
+if(NOT SKBUILD)
+  ament_package()
+endif()

--- a/src/accelerated_image_processor_python/README.md
+++ b/src/accelerated_image_processor_python/README.md
@@ -15,6 +15,9 @@ You can choose two types of installation depending on your demand.
 
 ### 1. Install with Python Package Manager
 
+Python package manager based installation builds the bindings through PEP517/scikit-build-core and does not require `ament_cmake`.
+If you need ROS package integration (`ament_package`, `colcon test`), use the ROS 2 package build path below.
+
 - `pip`
 
   ```bash


### PR DESCRIPTION
## PR Type

<!-- Select one and remove others. If an appropriate one is not listed, please write by yourself. -->

- Bug Fix

## Related Links

<!-- Please write related links to GitHub/Jira/Slack/etc. -->

## Description

<!-- Describe what this PR changes. -->

This pull request updates the CMake build configuration for the `accelerated_image_processor` packages to improve compatibility with both ROS 2 (`ament_cmake`) and Python package builds using scikit-build-core (PEP517). The main changes ensure that ROS-specific CMake logic is only run when not building via scikit-build, preventing conflicts and enabling smoother Python packaging.

The most important changes are:

**CMake/Build System Improvements:**

* Wrapped all `ament_*` and ROS-specific CMake commands in `if(NOT SKBUILD)` blocks to prevent them from running during scikit-build-core (Python PEP517) builds, which avoids unnecessary dependencies and errors. [[1]](diffhunk://#diff-844708e06e4e4d4dc1d12ef7ef0113894e192f0d0309abd0811d6bb03d4fd9b6R14-R16) [[2]](diffhunk://#diff-e36ae78cce54d8581d09ba4aa30bdda32300ce2e18eee708a31841dc45016e24R17-R20) [[3]](diffhunk://#diff-af9f4f52cfe1f8ab89e9ac42a7f5ac252619887424e5f4531d23628abe05ac46R17-R20) [[4]](diffhunk://#diff-86d8b2119ca297aa555df55ea0bac4f6970b658be58c95cf47ac71ceb0e87a36R22-R25) [[5]](diffhunk://#diff-86d8b2119ca297aa555df55ea0bac4f6970b658be58c95cf47ac71ceb0e87a36R36-R38) [[6]](diffhunk://#diff-86d8b2119ca297aa555df55ea0bac4f6970b658be58c95cf47ac71ceb0e87a36R142-R144)
* Updated all test-related CMake logic to only run when not building with scikit-build (`if(BUILD_TESTING AND NOT SKBUILD)`), ensuring tests are only enabled in ROS 2 builds. [[1]](diffhunk://#diff-844708e06e4e4d4dc1d12ef7ef0113894e192f0d0309abd0811d6bb03d4fd9b6L26-R36) [[2]](diffhunk://#diff-e36ae78cce54d8581d09ba4aa30bdda32300ce2e18eee708a31841dc45016e24L159-R173) [[3]](diffhunk://#diff-af9f4f52cfe1f8ab89e9ac42a7f5ac252619887424e5f4531d23628abe05ac46R58-R71) [[4]](diffhunk://#diff-86d8b2119ca297aa555df55ea0bac4f6970b658be58c95cf47ac71ceb0e87a36L119-R123)
* Adjusted library dependency logic to use `target_link_libraries` directly for scikit-build builds, and `ament_target_dependencies` for ROS 2 builds, ensuring correct linking in both environments. [[1]](diffhunk://#diff-e36ae78cce54d8581d09ba4aa30bdda32300ce2e18eee708a31841dc45016e24R86-R92) [[2]](diffhunk://#diff-e36ae78cce54d8581d09ba4aa30bdda32300ce2e18eee708a31841dc45016e24R117-R124) [[3]](diffhunk://#diff-af9f4f52cfe1f8ab89e9ac42a7f5ac252619887424e5f4531d23628abe05ac46R58-R71)

**Documentation:**

* Updated the Python package README to clarify that scikit-build-core-based installs do not require `ament_cmake`, and to direct users needing ROS integration to the appropriate build path.

These changes make the project more flexible and robust for both ROS 2 and Python packaging workflows.
## Review Procedure

<!-- Explain how to review this PR. -->

I tested with the following environment using docker:

<details>

<summary>Dockerfile: `docker/Dockerfile.python-non-ros-cuda`</summary>

```docker
# syntax=docker/dockerfile:1
#
# Verifies that accelerated_image_processor can be installed as a Python package
# from GitHub with uv in a CUDA-enabled but ROS2-free environment.
#
# Build from the repository root:
#   docker build -f docker/Dockerfile.python-non-ros-cuda .
#
# Override the Git ref when needed:
#   docker build -f docker/Dockerfile.python-non-ros-cuda \
#     --build-arg AIP_GIT_REF=refs/pull/38/head .

FROM nvidia/cuda:12.2.0-devel-ubuntu22.04

ARG AIP_GIT_URL=https://github.com/tier4/accelerated_image_processor.git
ARG AIP_GIT_REF=fix/python-install

ENV DEBIAN_FRONTEND=noninteractive \
    PIP_DISABLE_PIP_VERSION_CHECK=1 \
    PIP_NO_CACHE_DIR=1 \
    UV_LINK_MODE=copy

RUN apt-get update && apt-get install -y --no-install-recommends \
    build-essential \
    ca-certificates \
    cmake \
    git \
    libavcodec-dev \
    libavutil-dev \
    libboost-python-dev \
    libopencv-dev \
    libturbojpeg0-dev \
    ninja-build \
    pkg-config \
    python3-dev \
    python3-pip \
    python3-venv \
  && rm -rf /var/lib/apt/lists/*

RUN python3 -m pip install --upgrade pip uv

WORKDIR /workspace/aip_uv_consumer
RUN uv init --package --name aip-uv-consumer .

# Ensure CMake's non-ROS/scikit-build path never falls back to ROS packages.
# This intentionally installs from GitHub via `uv add git+https://...` instead
# of copying the local checkout into the image.
RUN CMAKE_ARGS="-DSKBUILD=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_DISABLE_FIND_PACKAGE_ament_cmake=TRUE -DCMAKE_DISABLE_FIND_PACKAGE_ament_cmake_auto=TRUE -DCMAKE_DISABLE_FIND_PACKAGE_ament_cmake_pytest=TRUE -DCMAKE_DISABLE_FIND_PACKAGE_ament_cmake_gtest=TRUE -DCMAKE_DISABLE_FIND_PACKAGE_ament_lint_auto=TRUE -DCMAKE_DISABLE_FIND_PACKAGE_python_cmake_module=TRUE" \
    uv add "git+${AIP_GIT_URL}@${AIP_GIT_REF}"

# Docker build does not run with the NVIDIA container runtime, so the host
# driver library (libcuda.so.1) is not mounted. Use CUDA's driver stub only for
# this build-time import smoke test; real GPU execution should use the host
# driver mounted by the NVIDIA container runtime.
RUN ln -sf /usr/local/cuda/lib64/stubs/libcuda.so /usr/local/cuda/lib64/stubs/libcuda.so.1

# Smoke test the installed wheel without requiring a visible GPU at build time.
RUN LD_LIBRARY_PATH=/usr/local/cuda/lib64/stubs:${LD_LIBRARY_PATH} uv run python - <<'PY'
import importlib.util

assert importlib.util.find_spec("rclpy") is None
assert importlib.util.find_spec("ament_package") is None

import accelerated_image_processor as aip
from accelerated_image_processor.common import Image, ImageEncoding, ImageFormat
from accelerated_image_processor.compression import CompressionType, create_compressor
from accelerated_image_processor.decompression import DecompressionType, create_decompressor

image = Image()
image.frame_id = "docker-smoke-test"
image.timestamp = 0
image.height = 1
image.width = 1
image.step = 3
image.encoding = ImageEncoding.RGB
image.format = ImageFormat.RAW
image.data = [0, 0, 0]
assert image.is_valid()

assert CompressionType.JPEG is not None
assert DecompressionType.VIDEO is not None
assert callable(create_compressor)
assert callable(create_decompressor)
print("accelerated_image_processor uv git dependency smoke test passed")
PY
```

</details>

Build

```bash
docker build -f docker/Dockerfile.python-non-ros-cuda -t aip-python-non-ros-cuda-uv-git-test .
```

Run

```bash
docker run --rm aip-python-non-ros-cuda-uv-git-test sh -c "cd /workspace/aip_uv_consumer && LD_LIBRARY_PATH=/usr/local/cuda/lib64/stubs:/usr/local/nvidia/lib:/usr/local/nvidia/lib64 uv run python - <<'PY'
import importlib.metadata
import importlib.util
import pathlib
import subprocess

assert importlib.util.find_spec('rclpy') is None
assert importlib.util.find_spec('ament_package') is None
print('installed version:', importlib.metadata.version('accelerated_image_processor'))
print(pathlib.Path('pyproject.toml').read_text())
print(subprocess.check_output(['uv', 'tree'], text=True))

from accelerated_image_processor.common import Image, ImageEncoding, ImageFormat
from accelerated_image_processor.compression import CompressionType, create_compressor
from accelerated_image_processor.decompression import DecompressionType, create_decompressor

img = Image()
img.frame_id = 'uv-git-runtime-test'
img.timestamp = 42
img.height = 2
img.width = 2
img.step = 6
img.encoding = ImageEncoding.RGB
img.format = ImageFormat.RAW
img.data = [0, 0, 0, 255, 0, 0, 0, 255, 0, 0, 0, 255]
assert img.is_valid()
assert CompressionType.JPEG is not None
assert DecompressionType.VIDEO is not None
assert callable(create_compressor)
assert callable(create_decompressor)
print('uv git dependency runtime smoke test passed')
PY"
```

Then, 

```bash
==========
== CUDA ==
==========

CUDA Version 12.2.0

Container image Copyright (c) 2016-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.

This container image and its contents are governed by the NVIDIA Deep Learning Container License.
By pulling and using the container, you accept the terms and conditions of this license:
https://developer.nvidia.com/ngc/nvidia-deep-learning-container-license

A copy of this license is made available in this container at /NGC-DL-CONTAINER-LICENSE for your convenience.

WARNING: The NVIDIA Driver was not detected.  GPU functionality will not be available.
   Use the NVIDIA Container Toolkit to start this container with GPU support; see
   https://docs.nvidia.com/datacenter/cloud-native/ .

Resolved 6 packages in 1ms
installed version: 0.0.0
[project]
name = "aip-uv-consumer"
version = "0.1.0"
description = "Add your description here"
readme = "README.md"
requires-python = ">=3.10"
dependencies = [
    "accelerated-image-processor",
]

[project.scripts]
aip-uv-consumer = "aip_uv_consumer:main"

[build-system]
requires = ["uv_build>=0.11.28,<0.12.0"]
build-backend = "uv_build"

[tool.uv.sources]
accelerated-image-processor = { git = "https://github.com/tier4/accelerated_image_processor.git", rev = "fix/python-install" }

aip-uv-consumer v0.1.0
└── accelerated-image-processor v0.0.0
    ├── numpy v2.2.6
    └── opencv-python v5.0.0.93
        └── numpy v2.2.6

uv git dependency runtime smoke test passed
```

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [x] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [x] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
