### PR TITLE
perf(python): efficient data convesion between numpy to raw

### DIFF
--- a/src/accelerated_image_processor_python/README.md
+++ b/src/accelerated_image_processor_python/README.md
@@ -59,6 +59,10 @@ image = Image.from_file("path/to/image")
 # Load an image from a numpy array
 height, width = 480, 640
 image = Image.from_numpy(np.zeros((height, width, 3), dtype=np.uint8))
+
+# Read image storage without converting each byte to a Python list element.
+# This is a read-only, zero-copy NumPy view by default.
+image_array = image.to_numpy()
 ```
 
 ### 2. Compress an image

--- a/src/accelerated_image_processor_python/README.md
+++ b/src/accelerated_image_processor_python/README.md
@@ -62,7 +62,7 @@ image = Image.from_numpy(np.zeros((height, width, 3), dtype=np.uint8))
 
 # Read image storage without converting each byte to a Python list element.
 # This is a read-only, zero-copy NumPy view by default.
-image_array = image.to_numpy()
+array = image.to_numpy()
 ```
 
 ### 2. Compress an image

--- a/src/accelerated_image_processor_python/accelerated_image_processor/common/__init__.py
+++ b/src/accelerated_image_processor_python/accelerated_image_processor/common/__init__.py
@@ -94,18 +94,7 @@ class Image(common_cpp.Image):
         storage. Keep this Image alive and do not reassign ``data`` while a view
         is in use. Set ``copy=True`` for independently owned mutable storage.
         """
-        array = np.frombuffer(self, dtype=np.uint8)
-        if self.format == ImageFormat.RAW:
-            expected_size = int(self.height) * int(self.step)
-            if array.size != expected_size:
-                raise ValueError(
-                    f"RAW image data has {array.size} bytes, expected {expected_size}"
-                )
-            if self.step == self.width * 3:
-                array = array.reshape((self.height, self.width, 3))
-            else:
-                array = array.reshape((self.height, self.step))
-        return array.copy() if copy else array
+        return image_to_numpy(self, copy=copy)
 
     @classmethod
     def from_file(cls, filepath: PathLike) -> Image:
@@ -121,6 +110,25 @@ class Image(common_cpp.Image):
         if cv_image is None:
             raise ValueError(f"Failed to read image: {filepath}")
         return cls.from_numpy(cv_image, ImageEncoding.BGR)
+
+
+def image_to_numpy(image: Image, *, copy: bool = False) -> np.ndarray:
+    """Return image data as a NumPy array.
+
+    By default the array is a read-only, zero-copy view of the C++ image
+    storage. Keep this Image alive and do not reassign ``data`` while a view
+    is in use. Set ``copy=True`` for independently owned mutable storage.
+    """
+    array = np.frombuffer(image.data, dtype=np.uint8)
+    if image.format == ImageFormat.RAW:
+        expected_size = int(image.height) * int(image.step)
+        if array.size != expected_size:
+            raise ValueError(f"RAW image data has {array.size} bytes, expected {expected_size}")
+        if image.step == image.width * 3:
+            array = array.reshape((image.height, image.width, 3))
+        else:
+            array = array.reshape((image.height, image.step))
+    return array.copy() if copy else array
 
 
 class CameraInfo(common_cpp.CameraInfo):

--- a/src/accelerated_image_processor_python/accelerated_image_processor/common/__init__.py
+++ b/src/accelerated_image_processor_python/accelerated_image_processor/common/__init__.py
@@ -87,26 +87,6 @@ class Image(common_cpp.Image):
 
         return image
 
-    def to_numpy(self, *, copy: bool = False) -> np.ndarray:
-        """Return image data as a NumPy array.
-
-        By default the array is a read-only, zero-copy view of the C++ image
-        storage. Keep this Image alive and do not reassign ``data`` while a view
-        is in use. Set ``copy=True`` for independently owned mutable storage.
-        """
-        array = np.frombuffer(self, dtype=np.uint8)
-        if self.format == ImageFormat.RAW:
-            expected_size = int(self.height) * int(self.step)
-            if array.size != expected_size:
-                raise ValueError(
-                    f"RAW image data has {array.size} bytes, expected {expected_size}"
-                )
-            if self.step == self.width * 3:
-                array = array.reshape((self.height, self.width, 3))
-            else:
-                array = array.reshape((self.height, self.step))
-        return array.copy() if copy else array
-
     @classmethod
     def from_file(cls, filepath: PathLike) -> Image:
         """Construct an image from a file.

--- a/src/accelerated_image_processor_python/accelerated_image_processor/common/__init__.py
+++ b/src/accelerated_image_processor_python/accelerated_image_processor/common/__init__.py
@@ -73,7 +73,7 @@ class Image(common_cpp.Image):
         image.encoding = encoding
         image.format = ImageFormat.RAW
 
-        data_u8 = data.astype(np.uint8)
+        data_u8 = np.ascontiguousarray(data, dtype=np.uint8)
 
         height, width, channels = data_u8.shape
         if channels != 3:
@@ -81,9 +81,31 @@ class Image(common_cpp.Image):
         image.height = int(height)
         image.width = int(width)
         image.step = int(width * channels)
-        image.data = data_u8.ravel().tolist()
+        # The binding consumes the contiguous buffer with one bulk memcpy. The
+        # previous tolist() path converted every pixel byte through a Python int.
+        image.data = data_u8
 
         return image
+
+    def to_numpy(self, *, copy: bool = False) -> np.ndarray:
+        """Return image data as a NumPy array.
+
+        By default the array is a read-only, zero-copy view of the C++ image
+        storage. Keep this Image alive and do not reassign ``data`` while a view
+        is in use. Set ``copy=True`` for independently owned mutable storage.
+        """
+        array = np.frombuffer(self, dtype=np.uint8)
+        if self.format == ImageFormat.RAW:
+            expected_size = int(self.height) * int(self.step)
+            if array.size != expected_size:
+                raise ValueError(
+                    f"RAW image data has {array.size} bytes, expected {expected_size}"
+                )
+            if self.step == self.width * 3:
+                array = array.reshape((self.height, self.width, 3))
+            else:
+                array = array.reshape((self.height, self.step))
+        return array.copy() if copy else array
 
     @classmethod
     def from_file(cls, filepath: PathLike) -> Image:

--- a/src/accelerated_image_processor_python/accelerated_image_processor/common/__init__.py
+++ b/src/accelerated_image_processor_python/accelerated_image_processor/common/__init__.py
@@ -94,7 +94,18 @@ class Image(common_cpp.Image):
         storage. Keep this Image alive and do not reassign ``data`` while a view
         is in use. Set ``copy=True`` for independently owned mutable storage.
         """
-        return image_to_numpy(self, copy=copy)
+        array = np.frombuffer(self, dtype=np.uint8)
+        if self.format == ImageFormat.RAW:
+            expected_size = int(self.height) * int(self.step)
+            if array.size != expected_size:
+                raise ValueError(
+                    f"RAW image data has {array.size} bytes, expected {expected_size}"
+                )
+            if self.step == self.width * 3:
+                array = array.reshape((self.height, self.width, 3))
+            else:
+                array = array.reshape((self.height, self.step))
+        return array.copy() if copy else array
 
     @classmethod
     def from_file(cls, filepath: PathLike) -> Image:
@@ -110,25 +121,6 @@ class Image(common_cpp.Image):
         if cv_image is None:
             raise ValueError(f"Failed to read image: {filepath}")
         return cls.from_numpy(cv_image, ImageEncoding.BGR)
-
-
-def image_to_numpy(image: Image, *, copy: bool = False) -> np.ndarray:
-    """Return image data as a NumPy array.
-
-    By default the array is a read-only, zero-copy view of the C++ image
-    storage. Keep this Image alive and do not reassign ``data`` while a view
-    is in use. Set ``copy=True`` for independently owned mutable storage.
-    """
-    array = np.frombuffer(image.data, dtype=np.uint8)
-    if image.format == ImageFormat.RAW:
-        expected_size = int(image.height) * int(image.step)
-        if array.size != expected_size:
-            raise ValueError(f"RAW image data has {array.size} bytes, expected {expected_size}")
-        if image.step == image.width * 3:
-            array = array.reshape((image.height, image.width, 3))
-        else:
-            array = array.reshape((image.height, image.step))
-    return array.copy() if copy else array
 
 
 class CameraInfo(common_cpp.CameraInfo):

--- a/src/accelerated_image_processor_python/src/binding.hpp
+++ b/src/accelerated_image_processor_python/src/binding.hpp
@@ -19,6 +19,10 @@
 #include <accelerated_image_processor_common/processor.hpp>
 
 #include <boost/python.hpp>
+#include <boost/python/extract.hpp>
+#include <boost/python/tuple.hpp>
+
+#include <pyerrors.h>
 
 #include <array>
 #include <cstring>
@@ -179,5 +183,33 @@ inline bp::object process_or_none(ProcessorT * self, const common::Image & image
 {
   auto result = self->process(image);
   return result.has_value() ? bp::object(*result) : bp::object();
+}
+
+inline bp::object image_to_numpy(const bp::object & self, bool copy = false)
+{
+  const auto & image = bp::extract<const common::Image &>(self)();
+  bp::object np = bp::import("numpy");
+  bp::object frombuffer(np.attr("frombuffer"));
+  bp::object uint8(np.attr("uint8"));
+  bp::object array = frombuffer(self, uint8);
+
+  if (image.format == common::ImageFormat::RAW) {
+    const size_t expected_size =
+      static_cast<size_t>(image.height) * static_cast<size_t>(image.step);
+    const size_t actual_size = bp::extract<size_t>(array.attr("size"))();
+    if (actual_size != expected_size) {
+      PyErr_Format(
+        PyExc_ValueError, "RAW image data has %zu bytes, expected %zu", actual_size, expected_size);
+      bp::throw_error_already_set();
+    }
+
+    if (image.step == image.width * 3) {
+      array = array.attr("reshape")(bp::make_tuple(image.height, image.width, 3));
+    } else {
+      array = array.attr("reshape")(bp::make_tuple(image.height, image.step));
+    }
+  }
+
+  return copy ? array.attr("copy")() : array;
 }
 }  // namespace accelerated_image_processor::python

--- a/src/accelerated_image_processor_python/src/binding.hpp
+++ b/src/accelerated_image_processor_python/src/binding.hpp
@@ -21,6 +21,7 @@
 #include <boost/python.hpp>
 
 #include <array>
+#include <cstring>
 #include <string>
 #include <vector>
 
@@ -54,6 +55,35 @@ void list_to_vector(std::vector<T> & vec, const bp::object & iterable)
   for (bp::ssize_t i = 0; i < len; ++i) {
     vec.emplace_back(bp::extract<T>(py_list[i]));
   }
+}
+
+/**
+ * @brief Copy a contiguous one-byte Python buffer into a byte vector.
+ *
+ * NumPy arrays, memoryviews, bytes, and bytearrays take this bulk-copy path. Other
+ * iterables retain the legacy element-by-element conversion for compatibility.
+ */
+inline void buffer_or_iterable_to_byte_vector(std::vector<uint8_t> & vec, const bp::object & object)
+{
+  Py_buffer view{};
+  if (PyObject_GetBuffer(object.ptr(), &view, PyBUF_CONTIG_RO) == 0) {
+    if (view.itemsize != 1) {
+      PyBuffer_Release(&view);
+      PyErr_SetString(PyExc_ValueError, "Image data buffer must have one-byte elements");
+      bp::throw_error_already_set();
+    }
+
+    vec.resize(static_cast<std::size_t>(view.len));
+    if (view.len > 0) {
+      std::memcpy(vec.data(), view.buf, static_cast<std::size_t>(view.len));
+    }
+    PyBuffer_Release(&view);
+    return;
+  }
+
+  // An unsupported-buffer error is expected for legacy list/tuple inputs.
+  PyErr_Clear();
+  list_to_vector<uint8_t>(vec, object);
 }
 
 /**

--- a/src/accelerated_image_processor_python/src/common.cpp
+++ b/src/accelerated_image_processor_python/src/common.cpp
@@ -31,6 +31,27 @@ using namespace accelerated_image_processor;  // NOLINT
 
 namespace
 {
+int image_getbuffer(PyObject * exporter, Py_buffer * view, int flags)
+{
+  try {
+    bp::object object(bp::handle<>(bp::borrowed(exporter)));
+    auto & image = bp::extract<common::Image &>(object)();
+
+    // Export decoded storage read-only. The Python object is retained by the
+    // memoryview/NumPy array, so the vector remains alive for the view lifetime.
+    return PyBuffer_FillInfo(
+      view, exporter, image.data.empty() ? nullptr : image.data.data(),
+      static_cast<Py_ssize_t>(image.data.size()), 1, flags);
+  } catch (const bp::error_already_set &) {
+    return -1;
+  }
+}
+
+PyBufferProcs image_buffer_procs = {
+  image_getbuffer,
+  nullptr,
+};
+
 #ifdef JETSON_AVAILABLE
 constexpr bool IS_JETSON_AVAILABLE = true;
 #else
@@ -146,8 +167,8 @@ BOOST_PYTHON_MODULE(accelerated_image_processor_python_common)
     .value("EQUIDISTANT", common::DistortionModel::EQUIDISTANT);
 
   // ------- Image -------
-  bp::class_<common::Image>("Image")
-    .def_readwrite("frame_id", &common::Image::frame_id)
+  bp::class_<common::Image> image_class("Image");
+  image_class.def_readwrite("frame_id", &common::Image::frame_id)
     .def_readwrite("timestamp", &common::Image::timestamp)
     .def_readwrite("height", &common::Image::height)
     .def_readwrite("width", &common::Image::width)
@@ -159,11 +180,15 @@ BOOST_PYTHON_MODULE(accelerated_image_processor_python_common)
       "data",  // [uint8_t; height * width * step]
       +[](const common::Image & self) { return python::vector_to_list<uint8_t>(self.data); },
       +[](common::Image & self, const bp::object & iterable) {
-        python::list_to_vector<uint8_t>(self.data, iterable);
+        python::buffer_or_iterable_to_byte_vector(self.data, iterable);
       })
     .add_property("pts", &get_pts, &set_pts)
     .add_property("flags", &get_flags, &set_flags)
     .def("is_valid", &common::Image::is_valid);
+
+  auto * image_type = reinterpret_cast<PyTypeObject *>(image_class.ptr());
+  image_type->tp_as_buffer = &image_buffer_procs;
+  PyType_Modified(image_type);
 
   // ------- CameraInfo -------
   bp::class_<common::CameraInfo>("CameraInfo")

--- a/src/accelerated_image_processor_python/src/common.cpp
+++ b/src/accelerated_image_processor_python/src/common.cpp
@@ -184,7 +184,8 @@ BOOST_PYTHON_MODULE(accelerated_image_processor_python_common)
       })
     .add_property("pts", &get_pts, &set_pts)
     .add_property("flags", &get_flags, &set_flags)
-    .def("is_valid", &common::Image::is_valid);
+    .def("is_valid", &common::Image::is_valid)
+    .def("to_numpy", &python::image_to_numpy, (bp::arg("self"), bp::arg("copy") = false));
 
   auto * image_type = reinterpret_cast<PyTypeObject *>(image_class.ptr());
   image_type->tp_as_buffer = &image_buffer_procs;

--- a/src/accelerated_image_processor_python/test/test_common.py
+++ b/src/accelerated_image_processor_python/test/test_common.py
@@ -113,20 +113,6 @@ def test_compressed_image_to_numpy():
     np.testing.assert_array_equal(array, np.arange(7, dtype=np.uint8))
 
 
-def test_image_to_numpy():
-    image = Image()
-    image.frame_id = "camera"
-    image.timestamp = 1234567890
-    image.height = 1080
-    image.width = 1920
-    image.step = 1920 * 3
-    image.encoding = ImageEncoding.RGB
-    image.format = ImageFormat.RAW
-    image.data = _make_image_array(1080, 1920).ravel().tolist()
-    image.pts = 0
-    image.flags = False
-
-
 def test_camera_info_initialization():
     height, width = 1080, 1920
 

--- a/src/accelerated_image_processor_python/test/test_common.py
+++ b/src/accelerated_image_processor_python/test/test_common.py
@@ -50,6 +50,27 @@ def test_image_from_numpy():
     assert image.encoding == ImageEncoding.RGB
     assert image.format == ImageFormat.RAW
     assert len(image.data) == height * width * 3
+    image_view = image.to_numpy()
+    assert image_view.shape == (height, width, 3)
+    assert not image_view.flags.writeable
+    np.testing.assert_array_equal(image_view, image_array)
+
+
+def test_image_buffer_input_is_independent_and_numpy_output_can_copy():
+    image_array = _make_image_array(8, 16)
+    image = Image.from_numpy(image_array)
+
+    image_array.fill(0)
+    assert np.any(image.to_numpy())
+
+    image_copy = image.to_numpy(copy=True)
+    assert image_copy.flags.writeable
+    image_copy.fill(0)
+    assert np.any(image.to_numpy())
+
+    image_view = image.to_numpy()
+    del image
+    assert np.any(image_view)
 
 
 def test_image_from_file(tmp_path):

--- a/src/accelerated_image_processor_python/test/test_common.py
+++ b/src/accelerated_image_processor_python/test/test_common.py
@@ -88,6 +88,45 @@ def test_image_from_file(tmp_path):
     assert len(image.data) == height * width * 3
 
 
+def test_image_to_numpy_with_padded_rows():
+    image = Image()
+    image.format = ImageFormat.RAW
+    image.height = 2
+    image.width = 2
+    image.step = 8
+    image.data = np.arange(16, dtype=np.uint8)
+
+    array = image.to_numpy()
+
+    assert array.shape == (2, 8)
+    np.testing.assert_array_equal(array, np.arange(16, dtype=np.uint8).reshape(2, 8))
+
+
+def test_compressed_image_to_numpy():
+    image = Image()
+    image.format = ImageFormat.JPEG
+    image.data = np.arange(7, dtype=np.uint8)
+
+    array = image.to_numpy()
+
+    assert array.shape == (7,)
+    np.testing.assert_array_equal(array, np.arange(7, dtype=np.uint8))
+
+
+def test_image_to_numpy():
+    image = Image()
+    image.frame_id = "camera"
+    image.timestamp = 1234567890
+    image.height = 1080
+    image.width = 1920
+    image.step = 1920 * 3
+    image.encoding = ImageEncoding.RGB
+    image.format = ImageFormat.RAW
+    image.data = _make_image_array(1080, 1920).ravel().tolist()
+    image.pts = 0
+    image.flags = False
+
+
 def test_camera_info_initialization():
     height, width = 1080, 1920
 


### PR DESCRIPTION
## PR Type

<!-- Select one and remove others. If an appropriate one is not listed, please write by yourself. -->

- Improvement

## Related Links

<!-- Please write related links to GitHub/Jira/Slack/etc. -->

## Description

<!-- Describe what this PR changes. -->

`Image` now implements Python's read-only buffer protocol and provides `Image.to_numpy()`.
`to_numpy()` returns a zero-copy NumPy view by default, while `copy=True` produces independent
mutable storage. `Image.from_numpy()` now passes a contiguous NumPy buffer directly to C++, where
one bulk `memcpy` replaces millions of Python-integer conversions. The existing `Image.data`
list getter and iterable setter remain available for compatibility.

Because a zero-copy view references the C++ vector, callers must not reassign `Image.data` while a
view is alive. The view retains the `Image` object itself, so deleting the original Python variable
does not invalidate the view.

### Benchmark

`Image` now implements Python's read-only buffer protocol and provides `Image.to_numpy()`.
`to_numpy()` returns a zero-copy NumPy view by default, while `copy=True` produces independent
mutable storage. `Image.from_numpy()` now passes a contiguous NumPy buffer directly to C++, where
one bulk `memcpy` replaces millions of Python-integer conversions. The existing `Image.data`
list getter and iterable setter remain available for compatibility.

Because a zero-copy view references the C++ vector, callers must not reassign `Image.data` while a
view is alive. The view retains the `Image` object itself, so deleting the original Python variable
does not invalidate the view.

| Direction                  |                              Before |                               After |    Speedup |
| -------------------------- | ----------------------------------: | ----------------------------------: | ---------: |
| NumPy input into `Image`   | 184.090 ms/frame (`list -> vector`) | 0.168 ms/frame (`buffer -> vector`) |  1,096.35× |
| Decoded `Image` into NumPy |  51.053 ms/frame (`vector -> list`) |     0.002 ms/frame (zero-copy view) | 24,396.76× |

## Review Procedure

<!-- Explain how to review this PR. -->

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [ ] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
